### PR TITLE
Decorator editor_required ensures login is required

### DIFF
--- a/cafebabel/articles/drafts/views.py
+++ b/cafebabel/articles/drafts/views.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, flash, redirect, render_template, request
-from flask_login import login_required
 
 from ...core.helpers import editor_required
 from ...users.models import User
@@ -10,14 +9,12 @@ drafts = Blueprint('drafts', __name__)
 
 @drafts.route('/')
 @editor_required
-@login_required
 def list():
     articles = Article.objects(status='draft')
     return render_template('articles/drafts/list.html', articles=articles)
 
 
 @drafts.route('/new/', methods=['get', 'post'])
-@login_required
 @editor_required
 def create():
     if request.method == 'POST':

--- a/cafebabel/articles/views.py
+++ b/cafebabel/articles/views.py
@@ -2,7 +2,6 @@ from http import HTTPStatus
 
 from flask import (Blueprint, abort, current_app, flash, redirect,
                    render_template, request, url_for)
-from flask_login import fresh_login_required, login_required
 
 from ..core.helpers import editor_required
 from ..users.models import User
@@ -40,7 +39,6 @@ def detail(slug, article_id):
 
 @articles.route(
     '/<regex("\w{24}"):article_id>/edit/', methods=['get', 'post'])
-@login_required
 @editor_required
 def edit(article_id):
     article = Article.objects.get_or_404(id=article_id, status='published')
@@ -57,8 +55,7 @@ def edit(article_id):
 
 
 @articles.route('/<regex("\w{24}"):article_id>/delete/', methods=['post'])
-@fresh_login_required
-@editor_required
+@editor_required(fresh=True)
 def delete(article_id):
     article = Article.objects.get_or_404(id=article_id)
     article.delete()

--- a/cafebabel/core/helpers.py
+++ b/cafebabel/core/helpers.py
@@ -1,12 +1,12 @@
 import re
 import unicodedata
-from functools import wraps
+from functools import partial, wraps
 from http import HTTPStatus
 from math import ceil
 
 import markdown as markdownlib
 from flask import Markup, abort
-from flask_login import current_user
+from flask_login import current_user, fresh_login_required, login_required
 from jinja2.filters import do_wordcount
 
 
@@ -26,16 +26,21 @@ def reading_time(text):
     return ceil(words / 250)
 
 
-def editor_required(func):
+def editor_required(func=None, fresh=False):
     """Decorator which ensure that the current user's has an editor role.
 
-    If you decorate a view with this, it must be used in conjunction with the
-    `(fresh_)login_required` decorator.
+    The optional `fresh` parameter will ensure that a `fresh_login_required`
+    is applied, otherwise a regular `login_required` check will be performed
+    *before* checking the role to ensure the appropriated redirection.
     """
-    @wraps(func)
-    def decorated_view(*args, **kwargs):
-        if not current_user.has_role('editor'):
-            abort(HTTPStatus.FORBIDDEN,
-                  'An editor is required to perform this action.')
-        return func(*args, **kwargs)
-    return decorated_view
+    if callable(func):
+        @wraps(func)
+        def decorated_view(*args, **kwargs):
+            if not current_user.has_role('editor'):
+                abort(HTTPStatus.FORBIDDEN,
+                      'An editor is required to perform this action.')
+            return func(*args, **kwargs)
+        _login_required = fresh and fresh_login_required or login_required
+        return _login_required(decorated_view)
+    else:
+        return partial(editor_required, fresh=fresh)

--- a/cafebabel/core/mixins.py
+++ b/cafebabel/core/mixins.py
@@ -37,7 +37,7 @@ class UploadableImageMixin:
 
     @classmethod
     def store_image(cls, sender, document, **kwargs):
-        if document._upload_image:
+        if document is not None and document._upload_image:
             document.has_image = True
             document._upload_image.save(str(document.image_path))
             document._upload_image = None

--- a/cafebabel/tests/test_articles.py
+++ b/cafebabel/tests/test_articles.py
@@ -177,6 +177,13 @@ def test_delete_article_regular_user_should_return_403(client, user, article):
     assert Article.objects.all().count() == 1
 
 
+def test_delete_article_no_user_should_redirect(client, user, article):
+    response = client.post(f'/article/{article.id}/delete/')
+    assert response.status_code == HTTPStatus.FOUND
+    assert '/login' in response.headers.get('Location')
+    assert Article.objects.all().count() == 1
+
+
 def test_delete_incorrect_id_should_return_404(client, editor, article):
     login(client, editor.email, 'secret')
     response = client.post(f'/article/{article.id}foo/delete/')


### PR DESCRIPTION
Fix #114

With optional parameter `fresh` to be able to require a `fresh_login_required` (vs. a simple `login_required`).