### PR TITLE
manually restarting the preprod server when deploying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deploy:
 	@echo "> Fetching master branch and updating sources."
 	${remote} "${goto_src} && git fetch origin ${branch} && git checkout ${branch} && git reset --hard FETCH_HEAD"
 	${remote} "${goto_src} && pip install -r requirements.txt"
-	${remote} "pkill flask && ~/start-preprod.sh &"
+	${remote} "pkill flask && source ~/cafebabel.com/venv/bin/activate && FLASK_APP=prod flask run >> ~/log/preprod-$(date +%Y%m%d).log 2>&1"
 
 install:
 	@echo "> Installing sources, dependencies and database."


### PR DESCRIPTION
The content of `start-preprod.sh` was:

```bash
#!/bin/bash

cd /home/preprod/cafebabel.com
source ./venv/bin/activate
export FLASK_APP=prod

while true
do
    flask run >> ~/log/preprod-$(date +%Y%m%d).log 2>&1
    sleep 5
done
```