### PR TITLE
WIP: added language in URL with home redirecting to default by browser

### DIFF
--- a/cafebabel/__init__.py
+++ b/cafebabel/__init__.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from urllib.parse import quote_plus
 
 import click
-from flask import Flask
+from flask import Flask, g
 from flask_mail import Mail
 from flask_mongoengine import MongoEngine
 from flask_security import MongoEngineUserDatastore, Security
@@ -59,13 +59,27 @@ def register_blueprints(app):
     from .core.views import cores
     from .users.views import users
 
+    @app.url_defaults
+    def add_lang(endpoint, values):
+        if 'lang' in values or not g.get('lang'):
+            return
+        if app.url_map.is_endpoint_expecting(endpoint, 'lang'):
+            values['lang'] = g.lang
+
+    @app.url_value_preprocessor
+    def retrieve_lang(endpoint, values):
+        if not (values and 'lang' in values):
+            return
+        g.lang = values.pop('lang', app.config['DEFAULT_LANGUAGE'])
+
     app.register_blueprint(cores, url_prefix='')
-    app.register_blueprint(articles, url_prefix='/article')
-    app.register_blueprint(tags, url_prefix='/article/tag')
-    app.register_blueprint(drafts, url_prefix='/article/draft')
-    app.register_blueprint(proposals, url_prefix='/article/proposal')
-    app.register_blueprint(translations, url_prefix='/article/translation')
-    app.register_blueprint(users, url_prefix='/profile')
+    app.register_blueprint(articles, url_prefix='/<lang>/article')
+    app.register_blueprint(tags, url_prefix='/<lang>/article/tag')
+    app.register_blueprint(drafts, url_prefix='/<lang>/article/draft')
+    app.register_blueprint(proposals, url_prefix='/<lang>/article/proposal')
+    app.register_blueprint(translations,
+                           url_prefix='/<lang>/article/translation')
+    app.register_blueprint(users, url_prefix='/<lang>/profile')
 
 
 def register_cli(app):

--- a/cafebabel/core/helpers.py
+++ b/cafebabel/core/helpers.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from math import ceil
 
 import markdown as markdownlib
-from flask import Markup, abort, current_app, request
+from flask import Markup, abort, current_app, request, g
 from flask_login import current_user, fresh_login_required, login_required
 from jinja2.filters import do_wordcount
 
@@ -62,9 +62,7 @@ def file_exceeds(file_, size):
 
 
 def current_language():
-    lang_domain = current_app.config.get('DOMAIN_LANGUAGES')
-    domain_lang = {v: k for k, v in lang_domain.items()}
-    return domain_lang.get(request.host, 'en')
+    return g.get('lang', current_app.config['DEFAULT_LANGUAGE'])
 
 
 def absolute(url):

--- a/cafebabel/core/views.py
+++ b/cafebabel/core/views.py
@@ -1,10 +1,20 @@
-from flask import Blueprint, current_app, render_template, send_from_directory
+from flask import (Blueprint, current_app, render_template, send_from_directory,
+                   redirect, url_for, request)
+
 
 cores = Blueprint('cores', __name__)
 
 
 @cores.route('/')
 def home():
+    lang = (request.accept_languages.best or '')[:2]
+    if lang not in dict(current_app.config['LANGUAGES']):
+        lang = current_app.config['DEFAULT_LANGUAGE']
+    return redirect(url_for('.home_lang', lang=lang))
+
+
+@cores.route('/<lang>/')
+def home_lang():
     return render_template('home.html')
 
 

--- a/cafebabel/tests/test_articles.py
+++ b/cafebabel/tests/test_articles.py
@@ -11,7 +11,7 @@ from .utils import login
 
 
 def test_access_published_article_should_return_200(client, published_article):
-    response = client.get(f'/article/{published_article.slug}-'
+    response = client.get(f'/en/article/{published_article.slug}-'
                           f'{published_article.id}/')
     assert response.status_code == HTTPStatus.OK
 
@@ -20,7 +20,7 @@ def test_access_article_with_large_slug_should_return_200(client,
                                                           published_article):
     published_article.slug = 'quite-large-slug-with-dashes'
     published_article.save()
-    response = client.get(f'/article/{published_article.slug}-'
+    response = client.get(f'/en/article/{published_article.slug}-'
                           f'{published_article.id}/')
     assert response.status_code == HTTPStatus.OK
 
@@ -28,7 +28,7 @@ def test_access_article_with_large_slug_should_return_200(client,
 def test_published_article_should_display_content(app, client,
                                                   published_article, user):
     published_article.author = user
-    response = client.get(f'/article/{published_article.slug}-'
+    response = client.get(f'/en/article/{published_article.slug}-'
                           f'{published_article.id}/')
     assert response.status_code == 200
     assert f'<h1>{published_article.title}</h1>' in response
@@ -42,13 +42,13 @@ def test_published_article_should_display_content(app, client,
     assert f'<span>{published_article.language}</span>' in response
     assert published_article.author.profile.name in response
     assert ('href="https://twitter.com/share?url=http%3A%2F%2Flocalhost%2F'
-            f'article%2F{published_article.slug}-{published_article.id}%2F'
+            f'en%2Farticle%2F{published_article.slug}-{published_article.id}%2F'
             f'&text={published_article.title}&via=cafebabel_eng"' in response)
     assert ('href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2F'
-            f'localhost%2Farticle%2F{published_article.slug}-'
+            f'localhost%2Fen%2Farticle%2F{published_article.slug}-'
             f'{published_article.id}%2F"' in response)
     assert '1 min' in response
-    assert ('<meta property=og:url content="http://localhost/article/'
+    assert ('<meta property=og:url content="http://localhost/en/article/'
             f'{published_article.slug}-{published_article.id}/">' in response)
     assert '<meta property=og:locale content="en">' in response
 
@@ -56,7 +56,7 @@ def test_published_article_should_display_content(app, client,
 def test_published_article_should_render_markdown(client, published_article):
     published_article.body = '## Body title\n> quote me'
     published_article.save()
-    response = client.get(f'/article/{published_article.slug}-'
+    response = client.get(f'/en/article/{published_article.slug}-'
                           f'{published_article.id}/')
     assert response.status_code == 200
     assert f'<h1>{published_article.title}</h1>' in response
@@ -65,37 +65,37 @@ def test_published_article_should_render_markdown(client, published_article):
 
 
 def test_access_no_article_should_return_404(client):
-    response = client.get(f'/article/foo-bar/')
+    response = client.get(f'/en/article/foo-bar/')
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_access_no_id_should_return_404(client):
-    response = client.get(f'/article/foobar/')
+    response = client.get(f'/en/article/foobar/')
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_access_old_slug_article_should_return_301(client, published_article):
-    response = client.get(f'/article/wrong-slug-{published_article.id}/')
+    response = client.get(f'/en/article/wrong-slug-{published_article.id}/')
     assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
 
 
 def test_access_article_form_regular_user_should_return_403(client, user,
                                                             article):
     login(client, user.email, 'password')
-    response = client.get(f'/article/{article.id}/edit/')
+    response = client.get(f'/en/article/{article.id}/edit/')
     assert response.status_code == HTTPStatus.FORBIDDEN
 
 
 def test_access_published_article_form_should_return_200(client, editor,
                                                          published_article):
     login(client, editor.email, 'password')
-    response = client.get(f'/article/{published_article.id}/edit/')
+    response = client.get(f'/en/article/{published_article.id}/edit/')
     assert response.status_code == HTTPStatus.OK
 
 
 def test_access_no_article_form_should_return_404(client, editor):
     login(client, editor.email, 'password')
-    response = client.get(f'/article/foobarbazquxquuxquuzcorg/edit/')
+    response = client.get(f'/en/article/foobarbazquxquuxquuzcorg/edit/')
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
@@ -107,7 +107,7 @@ def test_update_published_article_should_return_200(app, client, user, editor,
         'author': user.id,
         'language': app.config['LANGUAGES'][1][0],
     }
-    response = client.post(f'/article/{published_article.id}/edit/', data=data,
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data,
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
     assert get_flashed_messages() == ['Your article was successfully saved.']
@@ -125,7 +125,7 @@ def test_update_published_article_to_draft_redirect(app, client, user, editor,
         'language': app.config['LANGUAGES'][1][0],
         'status': 'draft'
     }
-    response = client.post(f'/article/{published_article.id}/edit/', data=data,
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data,
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
 
@@ -139,7 +139,7 @@ def test_update_published_article_with_tag(app, client, user, editor, tag,
         'language': app.config['LANGUAGES'][0][0],
         'tag-1': tag.name
     }
-    response = client.post(f'/article/{published_article.id}/edit/', data=data,
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data,
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
     assert get_flashed_messages() == ['Your article was successfully saved.']
@@ -159,7 +159,7 @@ def test_update_published_article_with_unkown_tag(app, client, user, editor,
         'tag-1': tag.name,
         'tag-2': tag2.name
     }
-    response = client.post(f'/article/{published_article.id}/edit/', data=data,
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data,
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
     assert get_flashed_messages() == ['Your article was successfully saved.']
@@ -177,7 +177,7 @@ def test_update_article_with_image_should_return_200(app, client, user, editor,
         'author': user.id,
         'image': (image_content, 'image-name.jpg'),
     }
-    response = client.post(f'/article/{published_article.id}/edit/', data=data,
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data,
                            content_type='multipart/form-data',
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
@@ -204,7 +204,7 @@ def test_update_article_with_image_unallowed_extension(
         'image': (image_content, 'image-name.zip'),
     }
     assert 'zip' not in app.config.get('ALLOWED_EXTENSIONS')
-    response = client.post(f'/article/{published_article.id}/edit/', data=data,
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data,
                            content_type='multipart/form-data',
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
@@ -224,7 +224,7 @@ def test_update_article_with_user_should_return_403(client, user,
         'title': 'updated',
         'author': user.id
     }
-    response = client.post(f'/article/{published_article.id}/edit/', data=data)
+    response = client.post(f'/en/article/{published_article.id}/edit/', data=data)
     assert response.status_code == HTTPStatus.FORBIDDEN
     published_article.reload()
     assert published_article.title == 'article title'
@@ -237,7 +237,7 @@ def test_update_unpublished_article_should_return_404(client, user, editor,
         'title': 'updated',
         'author': user.id
     }
-    response = client.post(f'/article/{article.id}/edit/', data=data)
+    response = client.post(f'/en/article/{article.id}/edit/', data=data)
     assert response.status_code == HTTPStatus.NOT_FOUND
     article.reload()
     assert article.title == 'article title'
@@ -245,7 +245,7 @@ def test_update_unpublished_article_should_return_404(client, user, editor,
 
 def test_delete_article_should_return_200(client, editor, article):
     login(client, editor.email, 'password')
-    response = client.post(f'/article/{article.id}/delete/',
+    response = client.post(f'/en/article/{article.id}/delete/',
                            follow_redirects=True)
     assert response.status_code == HTTPStatus.OK
     assert Article.objects.all().count() == 0
@@ -254,13 +254,13 @@ def test_delete_article_should_return_200(client, editor, article):
 
 def test_delete_article_regular_user_should_return_403(client, user, article):
     login(client, user.email, 'password')
-    response = client.post(f'/article/{article.id}/delete/')
+    response = client.post(f'/en/article/{article.id}/delete/')
     assert response.status_code == HTTPStatus.FORBIDDEN
     assert Article.objects.all().count() == 1
 
 
 def test_delete_article_no_user_should_redirect(client, user, article):
-    response = client.post(f'/article/{article.id}/delete/')
+    response = client.post(f'/en/article/{article.id}/delete/')
     assert response.status_code == HTTPStatus.FOUND
     assert '/login' in response.headers.get('Location')
     assert Article.objects.all().count() == 1
@@ -268,7 +268,7 @@ def test_delete_article_no_user_should_redirect(client, user, article):
 
 def test_delete_incorrect_id_should_return_404(client, editor, article):
     login(client, editor.email, 'password')
-    response = client.post(f'/article/{article.id}foo/delete/')
+    response = client.post(f'/en/article/{article.id}foo/delete/')
     assert response.status_code == HTTPStatus.NOT_FOUND
     assert Article.objects.all().count() == 1
 
@@ -276,7 +276,7 @@ def test_delete_incorrect_id_should_return_404(client, editor, article):
 def test_delete_inexistent_article_should_return_404(client, editor, article):
     article.delete()
     login(client, editor.email, 'password')
-    response = client.post(f'/article/{article.id}/delete/')
+    response = client.post(f'/en/article/{article.id}/delete/')
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
@@ -286,9 +286,9 @@ def test_access_published_article_should_link_translations(client, article,
     article.save()
     translation.status = 'published'
     translation.save()
-    response = client.get(f'/article/{article.slug}-{article.id}/')
+    response = client.get(f'/en/article/{article.slug}-{article.id}/')
     assert response.status_code == HTTPStatus.OK
-    assert ((f'<li class=translated-language><a href=/article/'
+    assert ((f'<li class=translated-language><a href=/en/article/'
              f'title-{translation.id}/>fr</a></li>') in response)
     assert ((f'<li class=to-translate-languages>'
              f'<a href="{url_for("translations.create")}'
@@ -301,24 +301,24 @@ def test_article_should_know_its_translations(client, article, translation):
 
 
 def test_article_to_translate_should_return_200(client):
-    response = client.get(f'/article/to-translate/')
+    response = client.get(f'/en/article/to-translate/')
     assert response.status_code == HTTPStatus.OK
 
 
 def test_article_to_translate_should_have_default_languages(client):
-    response = client.get(f'/article/to-translate/')
+    response = client.get(f'/en/article/to-translate/')
     assert '<option value=en selected>English</option>' in response
     assert '<option value=fr selected>Français</option>' in response
 
 
 def test_article_to_translate_should_filter_by_language(client):
-    response = client.get(f'/article/to-translate/?from=fr&to=es')
+    response = client.get(f'/en/article/to-translate/?from=fr&to=es')
     assert '<option value=fr selected>Français</option>' in response
     assert '<option value=es selected>Español</option>' in response
 
 
 def test_article_to_translate_with_unknown_language(client):
-    response = client.get(f'/article/to-translate/?from=xx@to=yy')
+    response = client.get(f'/en/article/to-translate/?from=xx@to=yy')
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
@@ -326,11 +326,11 @@ def test_article_to_translate_should_have_translation_links(
         app, client, article):
     language = app.config['LANGUAGES'][1][0]
     article.modify(language=language)
-    response = client.get(f'/article/to-translate/?from=fr&to=en')
-    assert (f'href="/article/translation/new/'
+    response = client.get(f'/en/article/to-translate/?from=fr&to=en')
+    assert (f'href="/en/article/translation/new/'
             f'?lang=en&original={article.id}">Translate in English</a>'
             in response)
-    assert (f'href="/article/translation/new/'
+    assert (f'href="/en/article/translation/new/'
             f'?lang=fr&original={article.id}">Translate in Français</a>'
             not in response)
 
@@ -338,11 +338,11 @@ def test_article_to_translate_should_have_translation_links(
 def test_translation_to_translate_should_not_have_original_language(
         client, article, translation):
     # Keep the `translation` fixture, even if not refered to.
-    response = client.get(f'/article/to-translate/')
-    assert (f'href=/article/translation/new/'
+    response = client.get(f'/en/article/to-translate/')
+    assert (f'href=/en/article/translation/new/'
             f'?lang=en&original={article.id}>Translate in English</a>'
             not in response)
-    assert (f'href=/article/translation/new/'
+    assert (f'href=/en/article/translation/new/'
             f'?lang=fr&original={article.id}>Translate in Français</a>'
             not in response)
 
@@ -352,8 +352,8 @@ def test_translation_to_translate_should_have_original_language(
     # Keep the `article` fixture, even if not refered to.
     language = app.config['LANGUAGES'][1][0]
     translation.modify(language=language)
-    response = client.get(f'/article/to-translate/?from=fr&to=es')
-    assert (f'href="/article/translation/new/'
+    response = client.get(f'/en/article/to-translate/?from=fr&to=es')
+    assert (f'href="/en/article/translation/new/'
             f'?lang=es&original={translation.original_article.id}">'
             f'Translate in Español</a>'
             in response)
@@ -363,7 +363,7 @@ def test_article_to_translate_should_have_only_other_links(
         app, client, article):
     language = app.config['LANGUAGES'][1][0]
     article.modify(language=language)
-    response = client.get(f'/article/to-translate/?from=en&to=fr')
+    response = client.get(f'/en/article/to-translate/?from=en&to=fr')
     assert 'Translate in ' not in response
 
 
@@ -381,7 +381,7 @@ def test_article_detail_contains_tags(client, app, tag, published_article):
     tag2 = Tag.objects.create(name='Sensational', language=language)
     published_article.modify(tags=[tag, tag2])
     response = client.get(
-        f'/article/{published_article.slug}-{published_article.id}/')
+        f'/en/article/{published_article.slug}-{published_article.id}/')
     assert response.status_code == HTTPStatus.OK
-    assert '<a href=/article/tag/wonderful/>Wonderful</a>' in response
-    assert '<a href=/article/tag/sensational/>Sensational</a>' in response
+    assert '<a href=/en/article/tag/wonderful/>Wonderful</a>' in response
+    assert '<a href=/en/article/tag/sensational/>Sensational</a>' in response

--- a/cafebabel/tests/test_base.py
+++ b/cafebabel/tests/test_base.py
@@ -1,8 +1,32 @@
+from http import HTTPStatus
+
+
+def test_homepage_is_redirecting_to_default_language(client):
+    response = client.get('/')
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers.get('location') == 'http://localhost/en/'
+
+
+def test_homepage_is_redirecting_to_browser_language(client):
+    response = client.get('/', headers={
+        'Accept-Language': 'fr-FR,fr;q=0.5',
+    })
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers.get('location') == 'http://localhost/fr/'
+
+
+def test_homepage_is_redirecting_unknown_language_to_default(client):
+        response = client.get('/', headers={
+            'Accept-Language': 'xx-XX,xx;q=0.5',
+        })
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.headers.get('location') == 'http://localhost/en/'
+
 
 def test_homepage_is_displaying(client):
-    response = client.get('/')
-    assert response.status_code == 200
-    assert ('<meta name=description content="Cafébabel is the first European participatory magazine made for young '
-            'Europeans across borders.">' in response)
-    assert '<meta property=og:url content="http://localhost/">' in response
+    response = client.get('/en')
+    assert ('<meta name=description content="Cafébabel is the first European '
+            'participatory magazine made for young Europeans across borders.">'
+            in response)
+    assert '<meta property=og:url content="http://localhost/en">' in response
     assert '<meta name=twitter:card content="summary">' in response

--- a/config.py
+++ b/config.py
@@ -67,24 +67,11 @@ class BaseConfig:
     MAX_CONTENT_LENGTH = 1024 * 1024 * 16  # Megabytes.
     USERS_IMAGE_MAX_CONTENT_LENGTH = 1024 * 500  # Kilobytes.
 
-    DOMAIN_LANGUAGES = {
-        'fr': 'cafebabel.fr',
-        'en': 'cafebabel.co.uk',
-        'de': 'cafebabel.de',
-        'es': 'cafebabel.es',
-        'it': 'cafebabel.it',
-    }
+    DEFAULT_LANGUAGE = LANGUAGES[0][0]
 
 
 class PreprodConfig(BaseConfig):
-
-    DOMAIN_LANGUAGES = {
-        'fr': 'preprod.cafebabel.fr',
-        'en': 'preprod.cafebabel.co.uk',
-        'de': 'preprod.cafebabel.de',
-        'es': 'preprod.cafebabel.es',
-        'it': 'preprod.cafebabel.it',
-    }
+    pass
 
 
 class DevelopmentConfig(BaseConfig):
@@ -102,8 +89,6 @@ class DevelopmentConfig(BaseConfig):
     ]
     EXPLAIN_TEMPLATE_LOADING = False
 
-    DOMAIN_LANGUAGES = {'en': 'localhost:5000'}
-
 
 class TestingConfig(BaseConfig):
     TESTING = True
@@ -113,5 +98,3 @@ class TestingConfig(BaseConfig):
     WTF_CSRF_ENABLED = False
     UPLOADS_FOLDER = Path(mkdtemp()) / 'cafebabel' / 'uploads'
     DEBUG_TB_ENABLED = False
-
-    DOMAIN_LANGUAGES = {'en': 'localhost'}


### PR DESCRIPTION
Managing languages is necessary for migrations as articles are contextual to their language.

The website is implementing the language in the URL instead of domain based.

TODO:
- [x] add languages in most urls
- [x] redirect homepage
- [ ] redirect archives
