### PR TITLE
Redirect old article based on Archive header, fix #228

### DIFF
--- a/cafebabel/archives/views.py
+++ b/cafebabel/archives/views.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from flask import Blueprint, redirect, request, url_for
+from flask import Blueprint, current_app, redirect, request, url_for
 
 from ..articles.models import Article
 
@@ -9,17 +9,18 @@ archives = Blueprint('archives', __name__)
 
 @archives.route('/<regex("[a-z-]+"):_tag>/<regex("[a-z]+"):_>/<_slug>.html')
 def archive(**kwargs):
+    archive_url = request.headers.get('Archive', request.url)
     # First deal with regular production redirections,
     # then fallback on redirections for preproduction.
     try:
-        article = Article.objects.get(archive__url=request.url)
+        article = Article.objects.get(archive__url=archive_url)
     except Article.DoesNotExist:
         # Only in use for preproduction testing, could be safely kept or
         # remove for production.
-        archive_url = request.url.replace('http://preprod.cafebabel.',
+        archive_url = archive_url.replace('http://preprod.cafebabel.',
                                           'http://www.cafebabel.')
         article = Article.objects.get_or_404(archive__url=archive_url)
-    return redirect(url_for('articles.detail', slug=article.slug,
-                            article_id=article.id, lang=article.language,
-                            _external=True),
+    redirect_to = url_for('articles.detail', slug=article.slug,
+                          article_id=article.id, lang=article.language)
+    return redirect(f'http://{current_app.config["DOMAIN_NAME"]}{redirect_to}',
                     HTTPStatus.MOVED_PERMANENTLY)

--- a/cafebabel/archives/views.py
+++ b/cafebabel/archives/views.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from flask import Blueprint, current_app, redirect, request, url_for
+from flask import Blueprint, redirect, request, url_for
 
 from ..articles.models import Article
 
@@ -10,17 +10,7 @@ archives = Blueprint('archives', __name__)
 @archives.route('/<regex("[a-z-]+"):_tag>/<regex("[a-z]+"):_>/<_slug>.html')
 def archive(**kwargs):
     archive_url = request.headers.get('Archive', request.url)
-    # First deal with regular production redirections,
-    # then fallback on redirections for preproduction.
-    try:
-        article = Article.objects.get(archive__url=archive_url)
-    except Article.DoesNotExist:
-        # Only in use for preproduction testing, could be safely kept or
-        # remove for production.
-        archive_url = archive_url.replace('http://preprod.cafebabel.',
-                                          'http://www.cafebabel.')
-        article = Article.objects.get_or_404(archive__url=archive_url)
+    article = Article.objects.get_or_404(archive__url=archive_url)
     redirect_to = url_for('articles.detail', slug=article.slug,
                           article_id=article.id, lang=article.language)
-    return redirect(f'http://{current_app.config["DOMAIN_NAME"]}{redirect_to}',
-                    HTTPStatus.MOVED_PERMANENTLY)
+    return redirect(redirect_to, HTTPStatus.MOVED_PERMANENTLY)

--- a/cafebabel/tests/test_articles_archives.py
+++ b/cafebabel/tests/test_articles_archives.py
@@ -6,7 +6,7 @@ from cafebabel.articles.models import ArticleArchive
 
 
 def test_archive_is_redirect_to_article_with_lang(client, published_article):
-    url = 'http://cafebabel.test/lifestyle/article/ancien-article.html'
+    url = 'http://cafebabel.test/lifestyle/article/old-article.html'
     published_article.modify(language='fr',
                              archive=ArticleArchive(id=1, url=url))
     response = client.get(url)
@@ -18,19 +18,12 @@ def test_archive_is_redirect_to_article_with_lang(client, published_article):
 
 def test_archive_is_redirect_from_production(app, client, published_article):
     url_prod = 'http://www.cafebabel.co.uk/lifestyle/article/old-article.html'
-    url_preprod = ('http://preprod.cafebabel.co.uk/lifestyle/article/'
-                   'old-article.html')
+    url_preprod = 'http://cafebabel.test/lifestyle/article/old-article.html'
     published_article.modify(archive=ArticleArchive(id=1, url=url_prod))
-    old_server_name = app.config['SERVER_NAME']
-    old_domain_name = app.config['DOMAIN_NAME']
-    app.config['SERVER_NAME'] = 'preprod.cafebabel.co.uk'
-    app.config['DOMAIN_NAME'] = 'cafebabel.redirect'
-    response = client.get(url_preprod)
-    app.config['SERVER_NAME'] = old_server_name
-    app.config['DOMAIN_NAME'] = old_domain_name
+    response = client.get(url_preprod, headers={'Archive': url_prod})
     assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
     assert response.location == (
-        f'http://cafebabel.redirect/en/article/{published_article.slug}-'
+        f'http://cafebabel.test/en/article/{published_article.slug}-'
         f'{published_article.id}/'
     )
 

--- a/cafebabel/tests/test_articles_archives.py
+++ b/cafebabel/tests/test_articles_archives.py
@@ -1,12 +1,10 @@
 from http import HTTPStatus
 
-from flask import url_for
-
 from cafebabel.articles.models import ArticleArchive
 
 
 def test_archive_is_redirect_to_article_with_lang(client, published_article):
-    url = 'http://cafebabel.test/lifestyle/article/old-article.html'
+    url = 'http://cafebabel.test/lifestyle/article/ancien-article.html'
     published_article.modify(language='fr',
                              archive=ArticleArchive(id=1, url=url))
     response = client.get(url)

--- a/cafebabel/tests/test_articles_archives.py
+++ b/cafebabel/tests/test_articles_archives.py
@@ -22,15 +22,15 @@ def test_archive_is_redirect_from_production(app, client, published_article):
                    'old-article.html')
     published_article.modify(archive=ArticleArchive(id=1, url=url_prod))
     old_server_name = app.config['SERVER_NAME']
+    old_domain_name = app.config['DOMAIN_NAME']
     app.config['SERVER_NAME'] = 'preprod.cafebabel.co.uk'
+    app.config['DOMAIN_NAME'] = 'cafebabel.redirect'
     response = client.get(url_preprod)
     app.config['SERVER_NAME'] = old_server_name
+    app.config['DOMAIN_NAME'] = old_domain_name
     assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
-    article_url = url_for('articles.detail', slug=published_article.slug,
-                          article_id=published_article.id,
-                          lang=published_article.language, _external=True)
-    assert response.location == article_url == (
-        f'http://preprod.cafebabel.co.uk/en/article/{published_article.slug}-'
+    assert response.location == (
+        f'http://cafebabel.redirect/en/article/{published_article.slug}-'
         f'{published_article.id}/'
     )
 

--- a/config.py
+++ b/config.py
@@ -6,12 +6,6 @@ from cafebabel.users.forms import MultipleHashLoginForm
 class BaseConfig:
     DEBUG = False
     SECRET_KEY = 'TODO'
-    # Warning: this is not the same as SERVER_NAME!
-    # We set our custom domain name key to avoid Flask restriction:
-    # if you set SERVER_NAME, only requests issued with that domain will
-    # be handled. In our case we want to be permissive to be able to
-    # redirect old articles from different domains.
-    DOMAIN_NAME = 'cafebabel.test'
 
     MONGODB_SETTINGS = {
         'db': 'cafebabel',
@@ -76,10 +70,6 @@ class BaseConfig:
     USERS_IMAGE_MAX_CONTENT_LENGTH = 1024 * 500  # Kilobytes.
 
     DEFAULT_LANGUAGE = LANGUAGES[0][0]
-
-
-class ProdConfig(BaseConfig):
-    DOMAIN_NAME = 'preprod.cafebabel.com'
 
 
 class DevelopmentConfig(BaseConfig):

--- a/config.py
+++ b/config.py
@@ -6,7 +6,12 @@ from cafebabel.users.forms import MultipleHashLoginForm
 class BaseConfig:
     DEBUG = False
     SECRET_KEY = 'TODO'
-    SERVER_NAME = 'cafebabel.test'
+    # Warning: this is not the same as SERVER_NAME!
+    # We set our custom domain name key to avoid Flask restriction:
+    # if you set SERVER_NAME, only requests issued with that domain will
+    # be handled. In our case we want to be permissive to be able to
+    # redirect old articles from different domains.
+    DOMAIN_NAME = 'cafebabel.test'
 
     MONGODB_SETTINGS = {
         'db': 'cafebabel',
@@ -74,7 +79,7 @@ class BaseConfig:
 
 
 class ProdConfig(BaseConfig):
-    SERVER_NAME = 'preprod.cafebabel.com'
+    DOMAIN_NAME = 'preprod.cafebabel.com'
 
 
 class DevelopmentConfig(BaseConfig):
@@ -95,6 +100,7 @@ class DevelopmentConfig(BaseConfig):
 
 class TestingConfig(BaseConfig):
     TESTING = True
+    SERVER_NAME = 'cafebabel.test'
     MONGODB_SETTINGS = {
         'db': 'cafebabel_test'
     }

--- a/prod.py
+++ b/prod.py
@@ -1,4 +1,4 @@
 from cafebabel import create_app, register_cli
 
-app = create_app('config.ProdConfig')
+app = create_app('config.BaseConfig')
 register_cli(app)


### PR DESCRIPTION
We set the header through nginx before being proxied to HTTPS and Flask. This way we can access it from our app.