### PR TITLE
Revert part of previous changes, refs #228

### DIFF
--- a/cafebabel/archives/views.py
+++ b/cafebabel/archives/views.py
@@ -10,7 +10,16 @@ archives = Blueprint('archives', __name__)
 @archives.route('/<regex("[a-z-]+"):_tag>/<regex("[a-z]+"):_>/<_slug>.html')
 def archive(**kwargs):
     archive_url = request.headers.get('Archive', request.url)
-    article = Article.objects.get_or_404(archive__url=archive_url)
+    # First deal with regular production redirections,
+    # then fallback on redirections for preproduction.
+    try:
+        article = Article.objects.get(archive__url=archive_url)
+    except Article.DoesNotExist:
+        # Only in use for preproduction testing, could be safely kept or
+        # remove for production.
+        archive_url = archive_url.replace('http://preprod.cafebabel.',
+                                          'http://www.cafebabel.')
+        article = Article.objects.get_or_404(archive__url=archive_url)
     redirect_to = url_for('articles.detail', slug=article.slug,
                           article_id=article.id, lang=article.language)
     return redirect(redirect_to, HTTPStatus.MOVED_PERMANENTLY)

--- a/cafebabel/archives/views.py
+++ b/cafebabel/archives/views.py
@@ -9,17 +9,7 @@ archives = Blueprint('archives', __name__)
 
 @archives.route('/<regex("[a-z-]+"):_tag>/<regex("[a-z]+"):_>/<_slug>.html')
 def archive(**kwargs):
-    archive_url = request.headers.get('Archive', request.url)
-    # First deal with regular production redirections,
-    # then fallback on redirections for preproduction.
-    try:
-        article = Article.objects.get(archive__url=archive_url)
-    except Article.DoesNotExist:
-        # Only in use for preproduction testing, could be safely kept or
-        # remove for production.
-        archive_url = archive_url.replace('http://preprod.cafebabel.',
-                                          'http://www.cafebabel.')
-        article = Article.objects.get_or_404(archive__url=archive_url)
-    redirect_to = url_for('articles.detail', slug=article.slug,
-                          article_id=article.id, lang=article.language)
-    return redirect(redirect_to, HTTPStatus.MOVED_PERMANENTLY)
+    article = Article.objects.get_or_404(archive__url__iendswith=request.path)
+    url = url_for('articles.detail', slug=article.slug, article_id=article.id,
+                  lang=article.language)
+    return redirect(url, HTTPStatus.MOVED_PERMANENTLY)

--- a/cafebabel/tests/test_articles.py
+++ b/cafebabel/tests/test_articles.py
@@ -46,16 +46,15 @@ def test_published_article_should_display_content(client, published_article,
             f'{published_article.creation_date.date()}</time>' in response)
     assert f'<span>{published_article.language}</span>' in response
     assert published_article.author.profile.name in response
-    assert ('href="https://twitter.com/share?'
-            'url=http%3A%2F%2Fcafebabel.test%2F'
+    assert ('href="https://twitter.com/share?url=http%3A%2F%2Flocalhost%2F'
             f'en%2Farticle%2F{published_article.slug}-{published_article.id}'
             f'%2F&text={published_article.title}&via=cafebabel_eng"'
             in response)
     assert ('href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2F'
-            f'cafebabel.test%2Fen%2Farticle%2F{published_article.slug}-'
+            f'localhost%2Fen%2Farticle%2F{published_article.slug}-'
             f'{published_article.id}%2F"' in response)
     assert '1 min' in response
-    assert ('<meta property=og:url content="http://cafebabel.test/en/article/'
+    assert ('<meta property=og:url content="http://localhost/en/article/'
             f'{published_article.slug}-{published_article.id}/">' in response)
     assert '<meta property=og:locale content="en">' in response
 
@@ -205,7 +204,7 @@ def test_update_article_with_image_should_return_200(app, client, user, editor,
     assert published_article.image_filename == 'image-name.jpg'
     assert Path(app.config.get('UPLOADS_FOLDER') / 'articles' /
                 published_article.image_filename).exists()
-    assert ('<meta property=og:image content="http://cafebabel.test/uploads/'
+    assert ('<meta property=og:image content="http://localhost/uploads/'
             f'articles/{published_article.image_filename}">' in response)
 
 

--- a/cafebabel/tests/test_articles_archives.py
+++ b/cafebabel/tests/test_articles_archives.py
@@ -4,40 +4,41 @@ from cafebabel.articles.models import ArticleArchive
 
 
 def test_archive_is_redirect_to_article_with_lang(client, published_article):
-    url = 'http://cafebabel.test/lifestyle/article/ancien-article.html'
+    url = 'http://localhost/lifestyle/article/ancien-article.html'
     published_article.modify(language='fr',
                              archive=ArticleArchive(id=1, url=url))
     response = client.get(url)
     assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
-    assert response.location == ('http://cafebabel.test/fr/article/'
+    assert response.location == ('http://localhost/fr/article/'
                                  f'{published_article.slug}-'
                                  f'{published_article.id}/')
 
 
 def test_archive_is_redirect_from_production(app, client, published_article):
     url_prod = 'http://www.cafebabel.co.uk/lifestyle/article/old-article.html'
-    url_preprod = 'http://cafebabel.test/lifestyle/article/old-article.html'
+    url_preprod = ('http://preprod.cafebabel.co.uk/lifestyle/article/'
+                   'old-article.html')
     published_article.modify(archive=ArticleArchive(id=1, url=url_prod))
     response = client.get(url_preprod, headers={'Archive': url_prod})
     assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
     assert response.location == (
-        f'http://cafebabel.test/en/article/{published_article.slug}-'
+        f'http://preprod.cafebabel.co.uk/en/article/{published_article.slug}-'
         f'{published_article.id}/'
     )
 
 
 def test_archive_is_redirect_to_translation(client, translation):
-    url = 'http://cafebabel.test/lifestyle/articolo/old-translation.html'
+    url = 'http://localhost/lifestyle/articolo/old-translation.html'
     translation.modify(archive=ArticleArchive(id=1, url=url),
                        status='published')
     response = client.get(url)
     assert response.status_code == HTTPStatus.MOVED_PERMANENTLY
-    article_url = (f'http://cafebabel.test/fr/article/{translation.slug}-'
+    article_url = (f'http://localhost/fr/article/{translation.slug}-'
                    f'{translation.id}/')
     assert response.location == article_url
 
 
 def test_archive_inexisting_renders_404(client, published_article):
-    url = 'http://cafebabel.test/lifestyle/article/non-existing-archive.html'
+    url = 'http://localhost/lifestyle/article/non-existing-archive.html'
     response = client.get(url)
     assert response.status_code == HTTPStatus.NOT_FOUND

--- a/cafebabel/tests/test_base.py
+++ b/cafebabel/tests/test_base.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 def test_homepage_is_redirecting_to_default_language(client):
     response = client.get('/')
     assert response.status_code == HTTPStatus.FOUND
-    assert response.headers.get('location') == 'http://cafebabel.test/en/'
+    assert response.headers.get('location') == 'http://localhost/en/'
 
 
 def test_homepage_is_displaying(client):
@@ -12,6 +12,6 @@ def test_homepage_is_displaying(client):
     assert ('<meta name=description content="Cafébabel is the first European '
             'participatory magazine made for young Europeans across borders.">'
             in response)
-    assert ('<meta property=og:url content="http://cafebabel.test/en/">'
+    assert ('<meta property=og:url content="http://localhost/en/">'
             in response)
     assert '<meta name=twitter:card content="summary">' in response

--- a/cafebabel/tests/test_language.py
+++ b/cafebabel/tests/test_language.py
@@ -6,7 +6,7 @@ def test_homepage_is_redirecting_to_browser_language(client):
         'Accept-Language': 'fr-FR,fr;q=0.5',
     })
     assert response.status_code == HTTPStatus.FOUND
-    assert response.headers.get('location') == 'http://cafebabel.test/fr/'
+    assert response.headers.get('location') == 'http://localhost/fr/'
 
 
 def test_homepage_is_redirecting_unknown_language_to_default(client):
@@ -14,11 +14,11 @@ def test_homepage_is_redirecting_unknown_language_to_default(client):
         'Accept-Language': 'xx-XX,xx;q=0.5',
     })
     assert response.status_code == HTTPStatus.FOUND
-    assert response.headers.get('location') == 'http://cafebabel.test/en/'
+    assert response.headers.get('location') == 'http://localhost/en/'
 
 
 def test_homepage_displays_languages_meta(client):
     response = client.get('/fr/')
     assert 'og:locale content="fr"' in response
-    assert 'og:url content="http://cafebabel.test/fr/"' in response
-    assert 'twitter:url content="http://cafebabel.test/fr/"' in response
+    assert 'og:url content="http://localhost/fr/"' in response
+    assert 'twitter:url content="http://localhost/fr/"' in response

--- a/cafebabel/tests/test_translations.py
+++ b/cafebabel/tests/test_translations.py
@@ -81,7 +81,7 @@ def test_translation_creation_should_redirect(app, client, user, article):
     assert response.status_code == HTTPStatus.FOUND
     translation = Translation.objects.first()
     assert (response.headers.get('Location') ==
-            f'http://cafebabel.test/en/article/translation/{translation.id}/')
+            f'http://localhost/en/article/translation/{translation.id}/')
     assert (get_flashed_messages() ==
             ['Your translation was successfully created.'])
 
@@ -221,7 +221,7 @@ def test_translation_update_values_should_redirect(client, user, translation):
     assert response.status_code == HTTPStatus.FOUND
     translation = Translation.objects.first()
     assert (response.headers.get('Location') ==
-            f'http://cafebabel.test/en/article/translation/{translation.id}/')
+            f'http://localhost/en/article/translation/{translation.id}/')
     assert translation.title == 'Modified title'
     assert (get_flashed_messages() ==
             ['Your translation was successfully updated.'])

--- a/config.py
+++ b/config.py
@@ -90,7 +90,6 @@ class DevelopmentConfig(BaseConfig):
 
 class TestingConfig(BaseConfig):
     TESTING = True
-    SERVER_NAME = 'cafebabel.test'
     MONGODB_SETTINGS = {
         'db': 'cafebabel_test'
     }


### PR DESCRIPTION
Especially the fact to fallback on redirection to preprod matching.

Get rid of SERVER_NAME even for tests.