### PR TITLE
allow textarea to resize on 'cut' event or when deleting content

### DIFF
--- a/cafebabel/static/js/textarea-change.js
+++ b/cafebabel/static/js/textarea-change.js
@@ -2,7 +2,7 @@
 Array.from(document.querySelectorAll('textarea')).forEach(textArea => {
   function resize() {
     textArea.style.height =
-      'auto' /* hack to allow textarea to be resiized when deleting or cut content */
+      'auto' /* hack to allow textarea to be resized when deleting or cut content */
     textArea.style.height = `${textArea.scrollHeight}px`
   }
 

--- a/cafebabel/static/js/textarea-change.js
+++ b/cafebabel/static/js/textarea-change.js
@@ -1,7 +1,8 @@
 /* Auto-expand textarea when typing http://jsfiddle.net/hmelenok/WM6Gq/ */
 Array.from(document.querySelectorAll('textarea')).forEach(textArea => {
   function resize() {
-    textArea.style.height = 'auto'
+    textArea.style.height =
+      'auto' /* hack to allow textarea to be resiized when deleting or cut content */
     textArea.style.height = `${textArea.scrollHeight}px`
   }
 

--- a/cafebabel/static/js/textarea-change.js
+++ b/cafebabel/static/js/textarea-change.js
@@ -1,6 +1,7 @@
 /* Auto-expand textarea when typing http://jsfiddle.net/hmelenok/WM6Gq/ */
 Array.from(document.querySelectorAll('textarea')).forEach(textArea => {
   function resize() {
+    textArea.style.height = 'auto'
     textArea.style.height = `${textArea.scrollHeight}px`
   }
 


### PR DESCRIPTION
If we dont put `textArea.style.height = 'auto'` it doesn't resize when deleting content :/