### PR TITLE
Fix duplicate comparison of mongo objects

### DIFF
--- a/cafebabel/articles/models.py
+++ b/cafebabel/articles/models.py
@@ -51,6 +51,11 @@ class Article(db.Document, UploadableImageMixin):
     def __str__(self):
         return self.title
 
+    def __eq__(self, other):
+        # We need to compare strings of primary keys because of mongo
+        # duality of ObjectIDs vs. raw strings.
+        return str(self.pk) == str(other.pk)
+
     @property
     def upload_subpath(self):
         return 'articles'

--- a/cafebabel/articles/translations/models.py
+++ b/cafebabel/articles/translations/models.py
@@ -35,7 +35,9 @@ class Translation(Article):
     def check_duplicate(cls, sender, document, **kwargs):
         first = Translation.objects(original_article=document.original_article,
                                     language=document.language).first()
-        if ((first and first != document) or
+        # We need to compare strings of primary keys because of mongo
+        # duality of ObjectIDs vs. raw strings.
+        if ((first and str(first.pk) != str(document.pk)) or
                 document.language == document.original_article.language):
             raise errors.NotUniqueError(
                 'This article already exists in this language.')

--- a/cafebabel/articles/translations/models.py
+++ b/cafebabel/articles/translations/models.py
@@ -35,9 +35,7 @@ class Translation(Article):
     def check_duplicate(cls, sender, document, **kwargs):
         first = Translation.objects(original_article=document.original_article,
                                     language=document.language).first()
-        # We need to compare strings of primary keys because of mongo
-        # duality of ObjectIDs vs. raw strings.
-        if ((first and str(first.pk) != str(document.pk)) or
+        if ((first and first != document) or
                 document.language == document.original_article.language):
             raise errors.NotUniqueError(
                 'This article already exists in this language.')


### PR DESCRIPTION
We need to compare strings of primary keys because of mongo duality of ObjectIDs vs. raw strings.