### PR TITLE
Change language on categories redirects, fix #297

### DIFF
--- a/cafebabel/__init__.py
+++ b/cafebabel/__init__.py
@@ -169,6 +169,7 @@ def register_context_processors(app):
         from .core import helpers
         return dict(
             get_languages=lambda: app.config.get('LANGUAGES', tuple()),
+            get_categories=lambda: app.config.get('CATEGORIES', tuple()),
             get_year=lambda: datetime.now().year,
             current_language=helpers.current_language(),
             lang_url_for=helpers.lang_url_for,

--- a/cafebabel/templates/base.html
+++ b/cafebabel/templates/base.html
@@ -61,6 +61,8 @@
         {% set lang_url = url_for('cores.home_lang', lang=lang_code) %}
         {% if article and article.id %}
           {% set lang_url = article.get_published_translation_url(lang_code) or lang_url %}
+        {% elif tag and tag.slug in get_categories() %}
+          {% set lang_url = url_for('tags.detail', slug=tag.slug, lang=lang_code) %}
         {% endif %}
         <li><a href={{ lang_url }}>{{ lang_code|upper }}</a></li>
       {% endif %}

--- a/cafebabel/tests/test_tags.py
+++ b/cafebabel/tests/test_tags.py
@@ -88,8 +88,6 @@ def test_tag_suggest_wrong_language(client, tag):
 
 
 def test_tag_detail(app, client, tag, published_article):
-    Tag.objects.create(name='Wonderful', summary='text chapo',
-                       language=app.config['LANGUAGES'][1][0])
     published_article.modify(tags=[tag])
     response = client.get('/en/article/tag/wonderful/')
     assert response.status_code == HTTPStatus.OK
@@ -196,3 +194,17 @@ def test_tag_categories_by_language(app, tag):
     impact = Tag.objects.create(name='Impact', language=language1)
     assert not Tag.objects.categories(language=language2)
     assert Tag.objects.categories(language=language1)[0].slug == impact.slug
+
+
+def test_tag_menu_categories_redirect(app, client):
+    Tag.objects.create(name='Raw', summary='text chapo',
+                       language=app.config['LANGUAGES'][0][0])
+    response = client.get('/en/article/tag/raw/')
+    assert response.status_code == HTTPStatus.OK
+    assert '<a href=/fr/article/tag/raw/>FR</a></li>' in response
+
+
+def test_tag_menu_regular_do_not_redirect(app, client, tag):
+    response = client.get(f'/en/article/tag/{tag.slug}/')
+    assert response.status_code == HTTPStatus.OK
+    assert f'<a href=/fr/article/tag/{tag.slug}/>FR</a></li>' not in response


### PR DESCRIPTION
Note that no check is performed to check if the target category exists prior to make the link available, it is intentional as it is costly and all categories should be present for all languages in a real case scenario.
