### PR TITLE
Do not set a publication date for drafts, fix #348

### DIFF
--- a/cafebabel/django_migrations.py
+++ b/cafebabel/django_migrations.py
@@ -205,6 +205,8 @@ def create_article(old_article):
             relateds=fields['relateds']
         ),
     }
+    if status == 'draft':
+        del data['publication_date']
     if is_gallery:
         data['body'] = aggregate_gallery_body(old_article['gallery'])
     translation_from = fields['translation_from']


### PR DESCRIPTION
As a side effect, new draft would not appear on the list page because they were preceded by ones with a publication_date

Warning: requires a new import of data from old prod.