### PR TITLE
change 'auto' to '0' to prevent from jumping when editing, fix #280

### DIFF
--- a/cafebabel/static/js/textarea-change.js
+++ b/cafebabel/static/js/textarea-change.js
@@ -1,7 +1,7 @@
 /* Auto-expand textarea when typing http://jsfiddle.net/hmelenok/WM6Gq/ */
 Array.from(document.querySelectorAll('textarea')).forEach(textArea => {
   function resize() {
-    textArea.style.height = 0 /* textarea is NOT resized when deleting or cut content, to hack it : 'auto' (but it jumps when editing and saving :-( */
+    textArea.style.height = 0 /* textarea is NOT resized when deleting or cut content, to hack it : 'auto' (but it jumps when editing and saving) :-( */
     textArea.style.height = `${textArea.scrollHeight}px`
   }
 

--- a/cafebabel/static/js/textarea-change.js
+++ b/cafebabel/static/js/textarea-change.js
@@ -1,7 +1,7 @@
 /* Auto-expand textarea when typing http://jsfiddle.net/hmelenok/WM6Gq/ */
 Array.from(document.querySelectorAll('textarea')).forEach(textArea => {
   function resize() {
-    textArea.style.height = 0 /* textarea is NOT resized when deleting or cut content, to hack it : 'auto' (but it jumps when editing and saving) :-( */
+    textArea.style.height = 0 /* textarea is NOT resized when deleting or cutting content, to hack it, we tried 'auto' but it jumps when editing and saving so we had to fallback on '0' :-( */
     textArea.style.height = `${textArea.scrollHeight}px`
   }
 

--- a/cafebabel/static/js/textarea-change.js
+++ b/cafebabel/static/js/textarea-change.js
@@ -1,8 +1,7 @@
 /* Auto-expand textarea when typing http://jsfiddle.net/hmelenok/WM6Gq/ */
 Array.from(document.querySelectorAll('textarea')).forEach(textArea => {
   function resize() {
-    textArea.style.height =
-      'auto' /* hack to allow textarea to be resized when deleting or cut content */
+    textArea.style.height = 0 /* textarea is NOT resized when deleting or cut content, to hack it : 'auto' (but it jumps when editing and saving :-( */
     textArea.style.height = `${textArea.scrollHeight}px`
   }
 


### PR DESCRIPTION
fix #280 
problem left : textarea aren't resized when cuting or deleting content 😢 