### PR TITLE
Make emails visible to editors on profiles, fix #207

### DIFF
--- a/cafebabel/templates/users/detail.html
+++ b/cafebabel/templates/users/detail.html
@@ -4,7 +4,7 @@
 
 {% block body_class %}profile-page{% endblock %}
 {% block body %}
-<h1>{{ user }}</h1>
+<h1>{{ user.profile.name or '' }}</h1>
 
 <section>
   <h2>About</h2>
@@ -22,7 +22,12 @@
   {% endif %}
 
   <ul class=info-profile>
-    <li><span>{{ user.profile.name or '' }}</span></li>
+    <li>
+      <span>{{ user.profile.name or '' }}</span>
+      {% if user.is_me() or current_user.has_role('editor') %}
+        / <span><a href="mailto:{{ user.email }}">{{ user.email }}</a></span>
+      {% endif %}
+    </li>
     <li><span><a href="{{ user.profile.website or '' }}" target=_blank>{{ user.profile.website or '' }}</a></span></li>
     <li>
       <p class=bio>

--- a/cafebabel/templates/users/detail.html
+++ b/cafebabel/templates/users/detail.html
@@ -25,11 +25,11 @@
     <li>
       <span>{{ user.profile.name or '' }}</span>
     </li>
+    {% if user.is_me() or current_user.has_role('editor') %}
     <li>
-      {% if user.is_me() or current_user.has_role('editor') %}
-        <a href="mailto:{{ user.email }}">{{ user.email }}</a>
-      {% endif %}
+      <a href="mailto:{{ user.email }}">{{ user.email }}</a>
     </li>
+    {% endif %}
     <li><span><a href="{{ user.profile.website or '' }}" target=_blank>{{ user.profile.website or '' }}</a></span></li>
     <li>
       <p class=bio>

--- a/cafebabel/templates/users/detail.html
+++ b/cafebabel/templates/users/detail.html
@@ -24,8 +24,10 @@
   <ul class=info-profile>
     <li>
       <span>{{ user.profile.name or '' }}</span>
+    </li>
+    <li>
       {% if user.is_me() or current_user.has_role('editor') %}
-        / <span><a href="mailto:{{ user.email }}">{{ user.email }}</a></span>
+        <a href="mailto:{{ user.email }}">{{ user.email }}</a>
       {% endif %}
     </li>
     <li><span><a href="{{ user.profile.website or '' }}" target=_blank>{{ user.profile.website or '' }}</a></span></li>

--- a/cafebabel/tests/test_profile.py
+++ b/cafebabel/tests/test_profile.py
@@ -11,7 +11,7 @@ def test_confirm_user_creates_default_profile(app):
                                password='password')
     with app.app_context():
         confirm_user(user)
-    assert user.profile.name == user.email
+    assert user.profile.name == 'Anonymous'
 
 
 def test_user_profile_has_list_of_published_articles_no_draft(client, article):

--- a/cafebabel/users/models.py
+++ b/cafebabel/users/models.py
@@ -22,7 +22,7 @@ class UserProfile(db.EmbeddedDocument, UploadableImageMixin):
     old_pk = db.IntField()  # In use for migrations (references in articles).
 
     def __str__(self):
-        return self.name or 'Anonymous'
+        return self.name
 
     def get_id(self):
         return self._instance.id
@@ -65,7 +65,7 @@ class User(db.Document, UserMixin):
     def post_save(cls, sender, document, **kwargs):
         if kwargs.get('created', False):
             # Create the profile only on creation (vs. update).
-            document.profile = UserProfile(name=document.email)
+            document.profile = UserProfile(name='Anonymous')
             document.save()
 
     @classmethod


### PR DESCRIPTION
And also to the current logged in user.

The email is clickable for now. No more default username fallback to email so we don’t leak it. Default set to `Anonymous` because they are legion!